### PR TITLE
Robust support for different iteration protocols

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -225,6 +225,11 @@ NotAnIterableError (from :class:`CannotCoerceError <validator_collection.errors.
 
 .. autoclass:: NotAnIterableError
 
+IterationFailedError (from :class:`NotAnIterableError <validator_collection.errors.NotAnIterableError>`)
+---------------------------------------------------------------------------------------------------------
+
+.. autoclass:: IterationFailedError
+
 NotCallableError (from :class:`ValueError <python:ValueError>`)
 ------------------------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,16 @@ Utility functions that are used to configure Py.Test context.
 """
 
 import abc
+import collections
 import os
 
 import pytest
+from validator_collection._compat import is_py2
+
+if is_py2:
+    Iterable = collections.Iterable
+else:
+    Iterable = collections.abc.Iterable
 
 
 def pytest_addoption(parser):
@@ -91,3 +98,39 @@ class MetaClassParentType(object):
 class MetaClassType(MetaClassParentType):
     """The child meta class type."""
     pass
+
+
+class GetItemIterable(object):
+    """A class that does not have a ``__iter__`` method, but does use
+    ``__getitem__``."""
+
+    items = (1, 2, 3, 4)
+
+    def __getitem__(self, key):
+        return self.items[key]
+
+
+class IterIterable(object):
+    """A class that has an ``__iter__`` method."""
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration()
+
+class IterableIterable(Iterable):
+    """A class that inherits from ``Iterable``."""
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration()
+
+
+class FalseIterable(Iterable):
+    """A class that inherits from ``Iterable``."""
+
+    def __iter__(self):
+        raise AttributeError('this simulates an AttributeError')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ class IterIterable(object):
     def __next__(self):
         raise StopIteration()
 
+    def next(self):
+        return self.__next__()
+
 class IterableIterable(Iterable):
     """A class that inherits from ``Iterable``."""
 
@@ -127,6 +130,9 @@ class IterableIterable(Iterable):
 
     def __next__(self):
         raise StopIteration()
+
+    def next(self):
+        return self.__next__()
 
 
 class FalseIterable(Iterable):

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -26,7 +26,8 @@ import validator_collection.checkers as checkers
 
 from validator_collection._compat import TimeZone
 
-from tests.conftest import MetaClassParentType, MetaClassType
+from tests.conftest import MetaClassParentType, MetaClassType, GetItemIterable, \
+    IterIterable, IterableIterable, FalseIterable
 
 
 ## CORE
@@ -51,6 +52,12 @@ from tests.conftest import MetaClassParentType, MetaClassType
     ([str], None, True),
 
     ([1, 2, 3, 4], {'allow_empty': True}, SyntaxError),
+
+    (GetItemIterable(), None, True),
+    (IterIterable(), None, True),
+    (IterableIterable(), None, True),
+
+    (FalseIterable(), None, True),
 
 ])
 def test_is_iterable(value, kwargs, expects):
@@ -278,9 +285,18 @@ def test_is_string(value, expects, coerce_value, minimum_length, maximum_length,
     (['test', 123], True, False, None, 1),
 
     (str, True, False, None, None),
+
+    (GetItemIterable(), False, False, None, None),
+    (IterIterable(), False, False, None, None),
+    (IterableIterable(), False, False, None, None),
+
+    (FalseIterable(), True, False, None, None),
+
 ])
 def test_is_iterable(value, fails, allow_empty, minimum_length, maximum_length):
     expects = not fails
+    if not fails:
+        iter(value)
     result = checkers.is_iterable(value,
                                   minimum_length = minimum_length,
                                   maximum_length = maximum_length)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -23,6 +23,7 @@ import pytest
 
 import validator_collection.validators as validators
 from validator_collection._compat import numeric_types, basestring
+from tests.conftest import GetItemIterable, IterIterable, IterableIterable, FalseIterable
 
 
 ## CORE
@@ -248,6 +249,12 @@ def test_uuid(value, fails, allow_empty):
     (['test', 123], True, False, 3, None),
     (['test', 123], True, False, None, 1),
 
+    (GetItemIterable(), False, False, None, None),
+    (IterIterable(), False, False, None, None),
+    (IterableIterable(), False, False, None, None),
+
+    (FalseIterable(), True, False, None, None),
+
 ])
 def test_iterable(value, fails, allow_empty, minimum_length, maximum_length):
     """Test the string validator."""
@@ -258,7 +265,7 @@ def test_iterable(value, fails, allow_empty, minimum_length, maximum_length):
                                         maximum_length = maximum_length)
         if value is not None:
             assert validated is not None
-            assert hasattr(validated, '__iter__')
+            iter(validated)
         else:
             assert validated is None
     else:

--- a/validator_collection/checkers.py
+++ b/validator_collection/checkers.py
@@ -488,7 +488,6 @@ def is_iterable(obj,
                                   minimum_length = minimum_length,
                                   maximum_length = maximum_length,
                                   **kwargs)
-        assert isinstance(obj, Iterable)
     except SyntaxError as error:
         raise error
     except Exception:

--- a/validator_collection/checkers.py
+++ b/validator_collection/checkers.py
@@ -13,7 +13,6 @@ import sys
 import validator_collection.validators as validators
 from validator_collection._compat import integer_types, basestring
 from validator_collection._decorators import disable_checker_on_env
-from collections.abc import Iterable
 
 # pylint: disable=W0613
 ## CORE

--- a/validator_collection/errors.py
+++ b/validator_collection/errors.py
@@ -165,6 +165,16 @@ class NotAnIterableError(CannotCoerceError):
     """
     pass
 
+class IterationFailedError(NotAnIterableError):
+    """Exception raised when a value conforms to one of Python's supported
+    iterable protocols, but iterating across the object produced an unexpected
+    Exception.
+
+    **INHERITS FROM:** :class:`TypeError <python:TypeError>` -> :class:`CannotCoerceError <validator_collection.errors.CannotCoerceError>` -> :class:`NotAnIterableError <validator_collection.errors.NotAnIterableError>`
+
+    """
+    pass
+
 
 class MaximumLengthError(ValueError):
     """Exception raised when a value exceeds a maximum allowed length.


### PR DESCRIPTION
Refactored @aivrit's patch to implement more comprehensive false-positive / false-negative checking. In particular, added:

1. Explicit checking of iteration capability using Python's built-in ``iter()`` function.
2. Unit tests to test each of Python's two supported iteration protocols (``__getitem__()`` and ``__iter__()``).
3. Removed the Python version-specific type-checking to check against the ``Iterable`` abstract base class (which can itself introduce false-positives, depending on implementation).
4. Added a new error which indicates that a given object *is* an iterable, but that iteration is failing for an unexpected / unsupported reason (likely an implementation error in the iterable class itself).